### PR TITLE
Update to latest Linear API changes

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -26,6 +26,9 @@ func doGraphQLQuery(ctx context.Context, url string, hc *http.Client, qreq *grap
 		return nil, nil, err
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
+	if linearAPIKey != "" {
+		httpReq.Header.Set("Authorization", linearAPIKey)
+	}
 
 	httpResp, err := hc.Do(httpReq)
 	if err != nil {

--- a/graphql.go
+++ b/graphql.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 )
 
 type graphqlQuery struct {
@@ -26,7 +27,7 @@ func doGraphQLQuery(ctx context.Context, url string, hc *http.Client, qreq *grap
 		return nil, nil, err
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
-	if linearAPIKey != "" {
+	if linearAPIKey != "" && os.Args[1] == "from-linear" {
 		httpReq.Header.Set("Authorization", linearAPIKey)
 	}
 

--- a/linear.go
+++ b/linear.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -66,15 +65,6 @@ func queryLinearIssues(ctx context.Context, hc *http.Client, before string) ([]*
 						}
 						createdAt
 						body
-					}
-				}
-				integrationResources(last: 10) {
-					nodes {
-						pullRequest {
-							number
-							repoName
-							repoLogin
-						}
 					}
 				}
 				attachments(last: 10) {
@@ -170,15 +160,6 @@ type linearIssue struct {
 			} `json:"relatedIssue"`
 		} `json:"nodes"`
 	} `json:"relations"`
-	IntegrationResources struct {
-		Nodes []struct {
-			PullRequest *struct {
-				Number    int    `json:"number"`
-				RepoLogin string `json:"repoLogin"`
-				RepoName  string `json:"repoName"`
-			} `json:"pullRequest"`
-		} `json:"nodes"`
-	} `json:"integrationResources"`
 	Parent struct {
 		Identifier string `json:"identifier"`
 	} `json:"parent"`
@@ -227,15 +208,15 @@ func (li *linearIssue) assignee() string {
 
 func (li *linearIssue) prs() []string {
 	var prs []string
-	for _, ir := range li.IntegrationResources.Nodes {
-		if ir.PullRequest != nil {
-			if ir.PullRequest.RepoLogin == orgName && ir.PullRequest.RepoName == repoName {
-				prs = append(prs, fmt.Sprintf("#%d", ir.PullRequest.Number))
-			} else {
-				prs = append(prs, fmt.Sprintf("%s/%s#%d", ir.PullRequest.RepoLogin, ir.PullRequest.RepoName, ir.PullRequest.Number))
-			}
-		}
-	}
+	// for _, ir := range li.IntegrationResources.Nodes {
+	// 	if ir.PullRequest != nil {
+	// 		if ir.PullRequest.RepoLogin == orgName && ir.PullRequest.RepoName == repoName {
+	// 			prs = append(prs, fmt.Sprintf("#%d", ir.PullRequest.Number))
+	// 		} else {
+	// 			prs = append(prs, fmt.Sprintf("%s/%s#%d", ir.PullRequest.RepoLogin, ir.PullRequest.RepoName, ir.PullRequest.Number))
+	// 		}
+	// 	}
+	// }
 	return prs
 }
 

--- a/main.go
+++ b/main.go
@@ -171,11 +171,11 @@ func (s *state) fromLinear(ctx context.Context) error {
 	}
 
 	lc := http.DefaultClient
-	if linearAPIKey != "" {
-		lc = oauth2.NewClient(ctx, oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: linearAPIKey},
-		))
-	}
+	// if linearAPIKey != "" {
+	// 	lc = oauth2.NewClient(ctx, oauth2.StaticTokenSource(
+	// 		&oauth2.Token{AccessToken: linearAPIKey},
+	// 	))
+	// }
 
 	iss := &issueState{
 		ID:         "",


### PR DESCRIPTION
Linear's GraphQL schema changes and no longer includes integrationResources, and authentication now uses either OAuth2 or a personal token created in your settings page. As we want a non-interactive auth flow, this PR removes the OAuth2 Authentication header as that includes a Bearer token which no longer valid, and adds it into the http request in graphql.go if args[1] is from-linear